### PR TITLE
feat: 대화 시작 시 캐릭터 정보를 저장하고 상황을 랜덤 배정하는 기능 추가

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="MZ@localhost" uuid="1e5b34cd-ffa4-4fa5-b0df-14e141ac4c16">
+    <data-source source="LOCAL" name="MZ@localhost" uuid="c7e0bc4a-5138-443f-8d38-8e264976f65f">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>

--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -1,4 +1,20 @@
 from rest_framework import serializers
+from .models import chat_room,character,user
+
+class ChatRoomSerializer(serializers.ModelSerializer):
+    character_id = serializers.IntegerField(write_only=True)
+    user_id = serializers.IntegerField(write_only=True)
+
+    class Meta:
+        model = chat_room
+        fields = ['user_id','character_id']
+    def create(self, validated_data):
+        character_id = validated_data.pop('character_id')
+        user_id = validated_data.pop('user_id')
+        character_instance = character.objects.get(character_id=character_id)
+        user_instance = user.objects.get(id =user_id)
+        chat_room_instance = chat_room.objects.create(character=character_instance, user=user_instance, **validated_data)
+        return chat_room_instance
 
 
 class AnswerSerializer(serializers.Serializer):

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-
+from .views import CreateChatRoomView
 from . import views
 
 appname = "chat"
 
 urlpatterns = [
     path('answers', views.AnswerView.as_view(), name='choice'),
+    path('start', CreateChatRoomView.as_view(), name='start_chat')
 ]

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -6,5 +6,5 @@ appname = "chat"
 
 urlpatterns = [
     path('answers', views.AnswerView.as_view(), name='choice'),
-    path('start', CreateChatRoomView.as_view(), name='start_chat')
+    path('start', views.CreateChatRoomView.as_view(), name='start_chat')
 ]

--- a/chat/views.py
+++ b/chat/views.py
@@ -4,9 +4,67 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.views import APIView
+from django.db.models.functions import Random
+from .models import character,episode
 
 from .serializers import AnswerSerializer
+from  .serializers import ChatRoomSerializer
 
+# episode 랜덤 함수
+def get_random_episode_id(episode_time_id):
+    random_episode = episode.objects.filter(episode_time_id=episode_time_id).order_by(Random()).first()
+    if random_episode is None:
+        return None
+    return random_episode.episode_id
+
+
+class CreateChatRoomView(APIView):
+    @swagger_auto_schema(
+        request_body=ChatRoomSerializer,
+        operation_id='대화시작 시 캐릭터 정보를 저장하고 상황을 랜덤 배정하는 API',
+    )
+    def post(self, request,*args, **kwargs):
+        serializer = ChatRoomSerializer(data=request.data)
+        if serializer.is_valid():
+            # 데이터베이스에 직렬화하여 저장
+            chat_room_instance = serializer.save()
+
+            # 저장된 데이터에서 character_id 추출
+            character_id = chat_room_instance.character.character_id
+
+            # 추출한 character_id를 가진 character 객체의 work_id 값 추출
+            character_instance = character.objects.get(character_id=character_id)
+            work_id = character_instance.work.work_id
+
+            if work_id == 1:  # 회사일 때
+                # episode_time_id = 1(출근)인 episode 객체의 episode_id 값 랜덤으로 가져오기
+                episode_id = get_random_episode_id(1)
+            else:  # 알바일 때
+                # episode_time_id = 5(고기집)인 episode 객체의 episode_id 값 랜덤으로 가져오기
+                episode_id = get_random_episode_id(5)
+
+            if episode_id is not None:
+                # GPT Message API 호출
+                url = request.build_absolute_uri(reverse('gpt:gpt-message'))
+                payload = {
+                    "character_id": character_id,
+                    "episode_id": episode_id
+                }
+                headers = {
+                    'Content-Type': 'application/json',
+                }
+                response = requests.post(url, json=payload, headers=headers)
+                if response.status_code == status.HTTP_202_ACCEPTED:
+                    return JsonResponse({
+                        'character_id': character_instance.character_id,
+                    }, status=status.HTTP_201_CREATED)
+                else:
+                    return JsonResponse(response.json(), status=response.status_code)
+            else:
+                return JsonResponse({'error': 'No episode found for the given episode_time_id'},
+                                    status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class AnswerView(APIView):
     # authentication_classes = [JWTAuthentication]

--- a/gpt/views.py
+++ b/gpt/views.py
@@ -60,6 +60,7 @@ class GetGPTAnswerView(APIView):
             return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+
 class GetGPTResultView(APIView):
     # authentication_classes = [JWTAuthentication]
     # permission_classes = [IsAuthenticated]

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -32,6 +32,8 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         model = user
         fields = ("user_email", "user_password", "user_name")
 
+
+
     def create(self, validated_data):
         new_user = user.objects.create(
             user_email=validated_data["user_email"],


### PR DESCRIPTION
# 설명
- 대화 시작 시 user_id와 character_id를  ChatRoomSerializer를 사용하여 POST 요청에서 받은 데이터를 검증하고 저장한다
- chat_room_instance에서 character_id를 기반으로 character 객체를 가져오고, 해당 객체의 work_id를 추출헌다
-  work_id(회사/알바)에 따라 episode_time_id(출근/고기집) 설정 후 , get_random_episode_id 함수를 사용하여 episode_id 값 랜덤으로 가져온다
- 랜덤하게 선택된 episode_id와 함께 GPT 메시지 API를 호출하여 응답을 처리한다

# 작업내용
1. 시리얼라이저 데이터 검증 및 저장
2. character_id와 work_id 추출
3. 랜덤 에피소드 함수 구현
4. GPT 메시지 API 호출


close #28
